### PR TITLE
Add auth header to invoice helpers and add quote helpers

### DIFF
--- a/src/lib/downloadInvoiceFromFunction.ts
+++ b/src/lib/downloadInvoiceFromFunction.ts
@@ -1,11 +1,22 @@
+import { supabase } from './supabaseClient'
+
 export async function downloadInvoiceFromFunction(invoiceId: string) {
   if (typeof window === 'undefined') return
 
   try {
     const html2pdf = (await import('html2pdf.js')).default
 
+    const {
+      data: { session },
+    } = await supabase.auth.getSession()
+
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_SUPABASE_FUNCTION_URL}/generate-invoice-pdf?invoice_id=${invoiceId}`
+      `${process.env.NEXT_PUBLIC_SUPABASE_FUNCTION_URL}/generate-invoice-pdf?invoice_id=${invoiceId}`,
+      {
+        headers: session?.access_token
+          ? { Authorization: `Bearer ${session.access_token}` }
+          : undefined,
+      }
     )
 
     if (!res.ok) {

--- a/src/lib/downloadQuoteFromFunction.ts
+++ b/src/lib/downloadQuoteFromFunction.ts
@@ -1,6 +1,6 @@
 import { supabase } from './supabaseClient'
 
-export async function previewInvoiceFromFunction(invoiceId: string) {
+export async function downloadQuoteFromFunction(quoteId: string) {
   if (typeof window === 'undefined') return
 
   try {
@@ -11,7 +11,7 @@ export async function previewInvoiceFromFunction(invoiceId: string) {
     } = await supabase.auth.getSession()
 
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_SUPABASE_FUNCTION_URL}/generate-invoice-pdf?invoice_id=${invoiceId}`,
+      `${process.env.NEXT_PUBLIC_SUPABASE_FUNCTION_URL}/generate-quote-pdf?quote_id=${quoteId}`,
       {
         headers: session?.access_token
           ? { Authorization: `Bearer ${session.access_token}` }
@@ -19,13 +19,18 @@ export async function previewInvoiceFromFunction(invoiceId: string) {
       }
     )
 
+    if (!res.ok) {
+      console.error('Failed to fetch quote HTML:', await res.text())
+      throw new Error('Fetch failed')
+    }
+
     const html = await res.text()
 
     const container = document.createElement('div')
     container.innerHTML = html
     document.body.appendChild(container)
 
-    await html2pdf().from(container).save(`invoice-${invoiceId}.pdf`)
+    await html2pdf().from(container).save(`quote-${quoteId}.pdf`)
     document.body.removeChild(container)
   } catch (err) {
     console.error('Download error:', err)

--- a/src/lib/previewQuoteFromFunction.ts
+++ b/src/lib/previewQuoteFromFunction.ts
@@ -1,6 +1,6 @@
 import { supabase } from './supabaseClient'
 
-export async function previewInvoiceFromFunction(invoiceId: string) {
+export async function previewQuoteFromFunction(quoteId: string) {
   if (typeof window === 'undefined') return
 
   try {
@@ -11,7 +11,7 @@ export async function previewInvoiceFromFunction(invoiceId: string) {
     } = await supabase.auth.getSession()
 
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_SUPABASE_FUNCTION_URL}/generate-invoice-pdf?invoice_id=${invoiceId}`,
+      `${process.env.NEXT_PUBLIC_SUPABASE_FUNCTION_URL}/generate-quote-pdf?quote_id=${quoteId}`,
       {
         headers: session?.access_token
           ? { Authorization: `Bearer ${session.access_token}` }
@@ -25,7 +25,7 @@ export async function previewInvoiceFromFunction(invoiceId: string) {
     container.innerHTML = html
     document.body.appendChild(container)
 
-    await html2pdf().from(container).save(`invoice-${invoiceId}.pdf`)
+    await html2pdf().from(container).save(`quote-${quoteId}.pdf`)
     document.body.removeChild(container)
   } catch (err) {
     console.error('Download error:', err)


### PR DESCRIPTION
## Summary
- include Authorization header when fetching `generate-invoice-pdf`
- create helpers for quote PDF generation

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6885c77d4b58832ab9dec1d1cc606b9a