### PR TITLE
Fix service worker update for cross-origin fetches

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,10 +1,12 @@
 // public/sw.js
 
 self.addEventListener('install', (event) => {
+  self.skipWaiting();
   console.log('Service Worker: Installed');
 });
 
 self.addEventListener('activate', (event) => {
+  self.clients.claim();
   console.log('Service Worker: Activated');
 });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
       if (process.env.NODE_ENV === 'production') {
         navigator.serviceWorker.register('/sw.js')
-          .then(reg => console.log('✅ Service Worker registered at:', reg.scope))
+          .then(reg => {
+            console.log('✅ Service Worker registered at:', reg.scope)
+            // 🚀 Ensure latest version is active
+            reg.update()
+          })
           .catch(err => console.error('❌ Service Worker registration failed:', err))
       } else {
         // ✅ Disable caching interference in development


### PR DESCRIPTION
## Summary
- update service worker to skipWaiting and claim clients so the new version activates immediately
- force-update the service worker when registering

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68861cf0faa8832aa89838322488f513