### PR TITLE
feat: add responsive layout and navigation

### DIFF
--- a/src/app/admin-dashboard/layout.tsx
+++ b/src/app/admin-dashboard/layout.tsx
@@ -5,6 +5,7 @@ import { useRouter, usePathname } from 'next/navigation'
 import Link from 'next/link'
 import { supabase } from '@/lib/supabaseClient'
 import toast from 'react-hot-toast'
+import Header from '@/components/Header'
 
 export default function AdminDashboardLayout({ children }: { children: ReactNode }) {
   const router = useRouter()
@@ -41,42 +42,45 @@ export default function AdminDashboardLayout({ children }: { children: ReactNode
   ]
 
   return (
-    <div className="flex min-h-screen bg-gray-100 text-black">
-      <aside className="w-64 bg-white shadow-md flex flex-col justify-between">
-        <div>
-          <div className="p-4 font-bold text-xl border-b">Neo Admin</div>
-          <nav className="flex flex-col p-4 space-y-2">
-            {navItems.map(({ label, href }) => (
-              <Link
-                key={href}
-                href={href}
-                className={`p-2 rounded hover:bg-gray-200 ${
-                  pathname === href ? 'bg-blue-100 text-blue-700 font-semibold' : ''
-                }`}
-              >
-                {label}
-              </Link>
-            ))}
-          </nav>
-        </div>
-        <div className="p-4">
-          <button
-            onClick={async () => {
-              await supabase.auth.signOut()
-              toast.success('Signed out')
-              router.push('/signin')
-            }}
-            className="w-full bg-red-500 text-white rounded p-2 hover:bg-red-600"
-          >
-            Sign Out
-          </button>
-        </div>
-      </aside>
+    <div className="min-h-screen bg-gray-100 text-black">
+      <Header />
+      <div className="flex">
+        <aside className="w-64 bg-white shadow-md flex flex-col justify-between">
+          <div>
+            <div className="p-4 font-bold text-xl border-b">Neo Admin</div>
+            <nav className="flex flex-col p-4 space-y-2">
+              {navItems.map(({ label, href }) => (
+                <Link
+                  key={href}
+                  href={href}
+                  className={`p-2 rounded hover:bg-gray-200 ${
+                    pathname === href ? 'bg-blue-100 text-blue-700 font-semibold' : ''
+                  }`}
+                >
+                  {label}
+                </Link>
+              ))}
+            </nav>
+          </div>
+          <div className="p-4">
+            <button
+              onClick={async () => {
+                await supabase.auth.signOut()
+                toast.success('Signed out')
+                router.push('/signin')
+              }}
+              className="w-full bg-red-500 text-white rounded p-2 hover:bg-red-600"
+            >
+              Sign Out
+            </button>
+          </div>
+        </aside>
 
-      <main className="flex-1 p-6">
-        <h1 className="text-2xl font-bold mb-6">Admin Dashboard</h1>
-        {children}
-      </main>
+        <main className="flex-1 p-6">
+          <h1 className="text-2xl font-bold mb-6">Admin Dashboard</h1>
+          {children}
+        </main>
+      </div>
     </div>
   )
 }

--- a/src/app/admin-dashboard/page.tsx
+++ b/src/app/admin-dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabaseClient'
 import toast from 'react-hot-toast'
+import ResponsiveLayout from '@/components/layouts/ResponsiveLayout'
 
 export default function AdminDashboardHome() {
   const [clientCount, setClientCount] = useState<number>(0)
@@ -40,15 +41,20 @@ export default function AdminDashboardHome() {
     fetchAdminStats()
   }, [])
 
-  if (loading) return <p className="p-4">Loading admin stats...</p>
+  if (loading) {
+    const loadingContent = <p className="p-4">Loading admin stats...</p>
+    return <ResponsiveLayout mobile={loadingContent} tablet={loadingContent} desktop={loadingContent} />
+  }
 
-  return (
+  const content = (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
       <AdminStatCard title="Total Clients" count={clientCount} />
       <AdminStatCard title="Total Invoices" count={invoiceCount} />
       <AdminStatCard title="Total Quotes" count={quoteCount} />
     </div>
   )
+
+  return <ResponsiveLayout mobile={content} tablet={content} desktop={content} />
 }
 
 const AdminStatCard = ({ title, count }: { title: string; count: number }) => (

--- a/src/app/capture/page.tsx
+++ b/src/app/capture/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
 import { useAuthRedirect } from '@/lib/useAuthRedirect'
 import Header from '@/components/Header'
+import ResponsiveLayout from '@/components/layouts/ResponsiveLayout'
 import ProductSelector from '@/components/ProductSelector'
 import { Trash2 } from 'lucide-react'
 import toast from 'react-hot-toast'
@@ -128,7 +129,7 @@ export default function CreateInvoicePage() {
     setLoading(false)
   }
 
-  return (
+  const content = (
     <div className="min-h-screen bg-gray-50 text-black">
       <Header />
       <div className="max-w-3xl mx-auto px-4 py-8">
@@ -224,4 +225,6 @@ export default function CreateInvoicePage() {
       </div>
     </div>
   )
+
+  return <ResponsiveLayout mobile={content} tablet={content} desktop={content} />
 }

--- a/src/app/client-dashboard/layout.tsx
+++ b/src/app/client-dashboard/layout.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { useEffect } from 'react'
 import { supabase } from '@/lib/supabaseClient'
 import toast from 'react-hot-toast'
+import Header from '@/components/Header'
 
 export default function Layout({ children }: { children: ReactNode }) {
   const router = useRouter()
@@ -43,42 +44,45 @@ useEffect(() => {
   ]
 
   return (
-    <div className="flex min-h-screen bg-gray-100 text-black">
-      <aside className="w-64 bg-white shadow-md flex flex-col justify-between">
-        <div>
-          <div className="p-4 font-bold text-xl border-b">Neo Invoice</div>
-          <nav className="flex flex-col p-4 space-y-2">
-            {navItems.map(({ label, href }) => (
-              <Link
-                key={href}
-                href={href}
-                className={`p-2 rounded hover:bg-gray-200 ${
-                  pathname === href ? 'bg-blue-100 text-blue-700 font-semibold' : ''
-                }`}
-              >
-                {label}
-              </Link>
-            ))}
-          </nav>
-        </div>
-        <div className="p-4">
-          <button
-            onClick={async () => {
-              await supabase.auth.signOut()
-              toast.success('Signed out')
-              router.push('/signin')
-            }}
-            className="w-full bg-red-500 text-white rounded p-2 hover:bg-red-600"
-          >
-            Sign Out
-          </button>
-        </div>
-      </aside>
+    <div className="min-h-screen bg-gray-100 text-black">
+      <Header />
+      <div className="flex">
+        <aside className="w-64 bg-white shadow-md flex flex-col justify-between">
+          <div>
+            <div className="p-4 font-bold text-xl border-b">Neo Invoice</div>
+            <nav className="flex flex-col p-4 space-y-2">
+              {navItems.map(({ label, href }) => (
+                <Link
+                  key={href}
+                  href={href}
+                  className={`p-2 rounded hover:bg-gray-200 ${
+                    pathname === href ? 'bg-blue-100 text-blue-700 font-semibold' : ''
+                  }`}
+                >
+                  {label}
+                </Link>
+              ))}
+            </nav>
+          </div>
+          <div className="p-4">
+            <button
+              onClick={async () => {
+                await supabase.auth.signOut()
+                toast.success('Signed out')
+                router.push('/signin')
+              }}
+              className="w-full bg-red-500 text-white rounded p-2 hover:bg-red-600"
+            >
+              Sign Out
+            </button>
+          </div>
+        </aside>
 
-      <main className="flex-1 p-6">
-        <h1 className="text-2xl font-bold mb-6">Client Dashboard</h1>
-        {children}
-      </main>
+        <main className="flex-1 p-6">
+          <h1 className="text-2xl font-bold mb-6">Client Dashboard</h1>
+          {children}
+        </main>
+      </div>
     </div>
   )
 }

--- a/src/app/client-dashboard/page.tsx
+++ b/src/app/client-dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabaseClient'
 import toast from 'react-hot-toast'
 import Link from 'next/link'
+import ResponsiveLayout from '@/components/layouts/ResponsiveLayout'
 
 export default function Page() {
   const [invoiceCount, setInvoiceCount] = useState<number>(0)
@@ -37,9 +38,12 @@ export default function Page() {
     fetchStats()
   }, [])
 
-  if (loading) return <p className="p-4">Loading stats...</p>
+  if (loading) {
+    const loadingContent = <p className="p-4">Loading stats...</p>
+    return <ResponsiveLayout mobile={loadingContent} tablet={loadingContent} desktop={loadingContent} />
+  }
 
-  return (
+  const content = (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
       <Link href="/client-dashboard/invoices" className="hover:opacity-80 transition">
         <StatCard title="Total Invoices" count={invoiceCount} />
@@ -49,6 +53,8 @@ export default function Page() {
       </Link>
     </div>
   )
+
+  return <ResponsiveLayout mobile={content} tablet={content} desktop={content} />
 }
 
 const StatCard = ({ title, count }: { title: string; count: number }) => (

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { supabase } from '@/lib/supabaseClient'
 import Header from '@/components/Header'
+import ResponsiveLayout from '@/components/layouts/ResponsiveLayout'
 import toast from 'react-hot-toast'
 
 export default function ProductsPage() {
@@ -42,7 +43,7 @@ export default function ProductsPage() {
     }
   }
 
-  return (
+  const content = (
     <div className="min-h-screen bg-gray-50 text-black">
       <Header />
       <div className="max-w-md mx-auto px-4 py-12">
@@ -92,4 +93,6 @@ export default function ProductsPage() {
       </div>
     </div>
   )
+
+  return <ResponsiveLayout mobile={content} tablet={content} desktop={content} />
 }

--- a/src/app/quote/capture/page.tsx
+++ b/src/app/quote/capture/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
 import { useAuthRedirect } from '@/lib/useAuthRedirect'
 import Header from '@/components/Header'
+import ResponsiveLayout from '@/components/layouts/ResponsiveLayout'
 import ProductSelector from '@/components/ProductSelector'
 import { Trash2 } from 'lucide-react'
 import toast from 'react-hot-toast'
@@ -112,7 +113,7 @@ export default function CreateQuotePage() {
     setLoading(false)
   }
 
-  return (
+  const content = (
     <div className="min-h-screen bg-gray-50 text-black">
       <Header />
       <div className="max-w-3xl mx-auto px-4 py-8">
@@ -247,4 +248,6 @@ export default function CreateQuotePage() {
       </div>
     </div>
   )
+
+  return <ResponsiveLayout mobile={content} tablet={content} desktop={content} />
 }

--- a/src/components/BurgerMenu.tsx
+++ b/src/components/BurgerMenu.tsx
@@ -27,7 +27,34 @@ export default function BurgerMenu() {
 
       {open && (
         <div className="absolute right-0 mt-2 w-48 bg-white border rounded shadow-lg z-50">
-
+          <Link
+            href="/"
+            className="block px-4 py-2 text-sm text-gray-800 hover:bg-gray-100"
+            onClick={() => setOpen(false)}
+          >
+            Home
+          </Link>
+          <Link
+            href="/quote/capture"
+            className="block px-4 py-2 text-sm text-gray-800 hover:bg-gray-100"
+            onClick={() => setOpen(false)}
+          >
+            Create Quote
+          </Link>
+          <Link
+            href="/capture"
+            className="block px-4 py-2 text-sm text-gray-800 hover:bg-gray-100"
+            onClick={() => setOpen(false)}
+          >
+            Create Invoice
+          </Link>
+          <Link
+            href="/products"
+            className="block px-4 py-2 text-sm text-gray-800 hover:bg-gray-100"
+            onClick={() => setOpen(false)}
+          >
+            Products
+          </Link>
           <Link
             href="/client-dashboard"
             className="block px-4 py-2 text-sm text-gray-800 hover:bg-gray-100"
@@ -40,7 +67,7 @@ export default function BurgerMenu() {
             className="block px-4 py-2 text-sm text-gray-800 hover:bg-gray-100"
             onClick={() => setOpen(false)}
           >
-            Update Profile
+            Profile
           </Link>
           <button
             onClick={() => {
@@ -49,7 +76,7 @@ export default function BurgerMenu() {
             }}
             className="block w-full text-left px-4 py-2 text-sm text-gray-800 hover:bg-gray-100"
           >
-            Logout
+            Sign Out
           </button>
         </div>
       )}

--- a/src/components/common/DesktopHeader.tsx
+++ b/src/components/common/DesktopHeader.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import BurgerMenu from '@/components/BurgerMenu'
 import { useUserInfo } from '@/lib/hooks/useUserInfo'
 
 export default function DesktopHeader() {
@@ -9,18 +10,16 @@ export default function DesktopHeader() {
   return (
     <header className="w-full bg-white shadow py-6">
       <div className="w-full max-w-6xl mx-auto px-6 flex justify-between items-center">
-        <h1 className="text-2xl font-bold">Neo-Invoice</h1>
-        <nav className="space-x-6">
+        <Link href="/" className="text-2xl font-bold">
+          Neo-Invoice
+        </Link>
+        <nav className="flex items-center space-x-6">
+          <Link href="/" className="text-gray-600 hover:text-black">Home</Link>
           <Link href="/profile" className="text-gray-600 hover:text-black">Profile</Link>
-          <Link href="/dashboard" className="text-gray-600 hover:text-black">Dashboard</Link>
-          {userName && (
-            <>
-              <span className="text-gray-500">Hi, {userName}</span>
-              <button onClick={handleSignOut} className="text-red-600 hover:underline">
-                Sign Out
-              </button>
-            </>
-          )}
+          <Link href="/client-dashboard" className="text-gray-600 hover:text-black">Dashboard</Link>
+          {userName && <span className="text-gray-500">Hi, {userName}</span>}
+          <button onClick={handleSignOut} className="text-red-600 hover:underline">Sign Out</button>
+          <BurgerMenu />
         </nav>
       </div>
     </header>

--- a/src/components/common/MobileHeader.tsx
+++ b/src/components/common/MobileHeader.tsx
@@ -1,13 +1,15 @@
 'use client'
 
-import { useUserInfo } from '@/lib/hooks/useUserInfo'
+import Link from 'next/link'
+import BurgerMenu from '@/components/BurgerMenu'
 
 export default function MobileHeader() {
-  const { userName } = useUserInfo()
   return (
     <header className="w-full bg-white shadow py-4 px-4 flex justify-between items-center">
-      <h1 className="text-xl font-bold">Neo-Invoice</h1>
-      {userName && <span className="text-sm text-gray-500">Hi, {userName}</span>}
+      <Link href="/" className="text-xl font-bold">
+        Neo-Invoice
+      </Link>
+      <BurgerMenu />
     </header>
   )
 }

--- a/src/components/common/TabletHeader.tsx
+++ b/src/components/common/TabletHeader.tsx
@@ -1,21 +1,22 @@
 'use client'
 
 import Link from 'next/link'
+import BurgerMenu from '@/components/BurgerMenu'
 import { useUserInfo } from '@/lib/hooks/useUserInfo'
 
 export default function TabletHeader() {
-  const { userName, handleSignOut } = useUserInfo()
+  const { handleSignOut } = useUserInfo()
   return (
     <header className="w-full bg-white shadow py-5 px-6 flex justify-between items-center">
-      <h1 className="text-2xl font-bold">Neo-Invoice</h1>
-      <nav className="space-x-4 text-sm">
+      <Link href="/" className="text-2xl font-bold">
+        Neo-Invoice
+      </Link>
+      <nav className="flex items-center space-x-4 text-sm">
+        <Link href="/" className="text-gray-600 hover:text-black">Home</Link>
         <Link href="/profile" className="text-gray-600 hover:text-black">Profile</Link>
-        <Link href="/dashboard" className="text-gray-600 hover:text-black">Dashboard</Link>
-        {userName && (
-          <button onClick={handleSignOut} className="text-red-600 hover:underline">
-            Sign Out
-          </button>
-        )}
+        <Link href="/client-dashboard" className="text-gray-600 hover:text-black">Dashboard</Link>
+        <button onClick={handleSignOut} className="text-red-600 hover:underline">Sign Out</button>
+        <BurgerMenu />
       </nav>
     </header>
   )


### PR DESCRIPTION
## Summary
- add burger menu navigation to all header variants
- wrap invoice, quote, product, client dashboard and admin dashboard pages with ResponsiveLayout
- expose global header on dashboard layouts for consistent navigation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ce1585f0c832a8fae790f159ad5d5